### PR TITLE
Limit monitoring tool to Windows-only polling backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.msi
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,85 @@
+# Bus Hound Lite
+
+Bus Hound Lite 是一个专为 **Windows** 平台设计的命令行工具，用于模拟 Bus Hound 的常用功能。它能够在用户态环境中监控 USB 设备的热插拔事件，并将串口通信记录为结构化的 JSON 日志，帮助嵌入式和驱动开发人员在 Windows 桌面环境中快速定位问题。
+
+## 功能概述
+
+- **USB 监控**：
+  - 自动检测 USB 设备的插入和拔出事件（仅支持 Windows 10/11）。
+  - 自动提取厂商 ID、产品 ID、设备地址等基础信息。
+  - 通过周期性轮询 `pyusb` 检测设备列表变化，部署简单，无需手动维护消息循环。
+
+- **串口监控**：
+  - 通过 [`pyserial`](https://pyserial.readthedocs.io/) 捕获串口输入数据。
+  - 将原始数据以十六进制字符串的形式输出，便于后续分析或导入到其他工具中。
+  - 通过 `--baudrate` 参数快速调整串口波特率。
+
+- **JSON 日志输出**：
+  - 所有事件均使用统一的 JSON 结构输出，支持写入到文件或标准输出。
+  - 方便与现有的日志收集或数据分析流水线整合。
+
+## 安装依赖
+
+```bash
+pip install -r requirements.txt
+```
+
+该项目仅支持 Windows 平台，使用前需要在目标设备上安装 [`libusb`](https://libusb.info/) 驱动，以便 `pyusb` 能够访问硬件。
+
+## 使用示例
+
+监控 USB 热插拔事件并输出到终端：
+
+```bash
+python -m bus_hound_tool.cli --usb
+```
+
+同时监控 USB 和串口，并将所有事件追加写入 `logs/session.jsonl`：
+
+```bash
+python -m bus_hound_tool.cli --usb --serial COM3 --log-file logs/session.jsonl
+```
+
+## 事件格式
+
+示例 USB 事件：
+
+```json
+{
+  "action": "attach",
+  "timestamp": "2024-05-18T12:30:11.123456Z",
+  "device": {
+    "vendor_id": "0x1234",
+    "product_id": "0xabcd",
+    "bus": "1",
+    "address": "5",
+    "manufacturer": "Demo",
+    "product": "Virtual USB Device",
+    "serial_number": "ABCDEF"
+  }
+}
+```
+
+示例串口事件：
+
+```json
+{
+  "timestamp": "2024-05-18T12:31:02.000001Z",
+  "direction": "in",
+  "payload": "48656c6c6f20555342"
+}
+```
+
+## 开发与测试
+
+项目使用 `pytest` 编写单元测试：
+
+```bash
+pytest
+```
+
+由于测试环境通常无法访问真实硬件，测试中通过注入模拟的串口对象和伪造的 USB 枚举结果来确保逻辑正确。
+
+## 许可证
+
+MIT License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "bus-hound-lite"
+version = "0.1.0"
+description = "Lightweight USB and serial monitoring helper inspired by Bus Hound"
+readme = "README.md"
+authors = [{name = "Bus Hound Lite Maintainers"}]
+requires-python = ">=3.9"
+dependencies = [
+    "pyusb>=1.2.1",
+    "pyserial>=3.5",
+]
+
+[project.scripts]
+bus-hound-lite = "bus_hound_tool.cli:main"
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["tests"]
+markers = [
+    "asyncio: mark a test as asyncio.",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyusb>=1.2.1
+pyserial>=3.5

--- a/src/bus_hound_tool/__init__.py
+++ b/src/bus_hound_tool/__init__.py
@@ -1,0 +1,13 @@
+"""Utility package for monitoring USB and serial activity.
+
+This package exposes helpers that mimic a small subset of the
+capabilities of the Bus Hound analyser.  It focuses on developer
+productivity features that can be exercised from a regular user space
+process, such as enumerating USB devices, following hot‑plug events and
+mirroring serial line traffic to structured log files.
+"""
+
+from .usb_monitor import USBMonitor
+from .serial_monitor import SerialMonitor
+
+__all__ = ["USBMonitor", "SerialMonitor"]

--- a/src/bus_hound_tool/cli.py
+++ b/src/bus_hound_tool/cli.py
@@ -1,0 +1,98 @@
+"""Command line interface for the lightweight Bus Hound clone."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import pathlib
+import sys
+from typing import Iterable, Optional
+
+from .serial_monitor import SerialMonitor
+from .usb_monitor import USBMonitor
+
+
+def _open_output(path: Optional[str]):
+    if not path:
+        return sys.stdout
+    file_path = pathlib.Path(path)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    return file_path.open("a", encoding="utf-8")
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="bus-hound-lite",
+        description=(
+            "Monitor USB hot-plug events and serial line traffic on Windows"
+            " hosts from the command line."
+        ),
+    )
+    parser.add_argument(
+        "--log-file",
+        help="Write JSON events to the specified file instead of stdout.",
+    )
+    parser.add_argument(
+        "--usb",
+        action="store_true",
+        help="Enable USB hot-plug monitoring.",
+    )
+    parser.add_argument(
+        "--serial",
+        metavar="PORT",
+        help="Enable serial monitoring on the given port (e.g. COM3).",
+    )
+    parser.add_argument(
+        "--baudrate",
+        type=int,
+        default=115200,
+        help="Baud rate to use when opening the serial port (default: 115200).",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=2.0,
+        help="Polling interval used by the USB monitor (default: 2.0s).",
+    )
+    return parser
+
+
+async def _run_monitors(args: argparse.Namespace) -> None:
+    output = _open_output(args.log_file)
+    tasks = []
+    try:
+        if args.usb:
+            usb_monitor = USBMonitor(poll_interval=args.poll_interval, output=output)
+            tasks.append(asyncio.create_task(usb_monitor.run()))
+
+        if args.serial:
+            serial_monitor = SerialMonitor(
+                args.serial,
+                baudrate=args.baudrate,
+                output=output,
+            )
+            tasks.append(asyncio.create_task(serial_monitor.run()))
+
+        if not tasks:
+            raise SystemExit("No monitor selected. Use --usb and/or --serial.")
+
+        await asyncio.gather(*tasks)
+    finally:
+        if output is not sys.stdout:
+            output.close()
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    parser = create_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    try:
+        asyncio.run(_run_monitors(args))
+    except KeyboardInterrupt:
+        return 1
+    except Exception as exc:  # pragma: no cover - top level safety net
+        parser.error(str(exc))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/src/bus_hound_tool/serial_monitor.py
+++ b/src/bus_hound_tool/serial_monitor.py
@@ -1,0 +1,109 @@
+"""Serial monitoring utilities."""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import datetime as _dt
+import json
+import sys
+from dataclasses import dataclass, asdict
+from typing import Callable, Optional
+
+
+def _utc_timestamp() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(frozen=True)
+class SerialEvent:
+    """Structured serial line event."""
+
+    timestamp: str
+    direction: str
+    payload: str
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), ensure_ascii=False)
+
+
+class SerialMonitor:
+    """Mirror traffic on a serial port to JSON formatted log entries.
+
+    The monitor is intentionally designed to be testable: a custom
+    ``serial_factory`` can be supplied so that unit tests can feed bytes to
+    the monitor without touching real hardware.
+    """
+
+    def __init__(
+        self,
+        port: str,
+        *,
+        baudrate: int = 115200,
+        bytesize: int = 8,
+        parity: str = "N",
+        stopbits: int = 1,
+        timeout: float = 0.1,
+        chunk_size: int = 1024,
+        serial_factory: Optional[Callable[[], "serial.SerialBase"]] = None,
+        output=None,
+    ) -> None:
+        self.port = port
+        self.baudrate = baudrate
+        self.bytesize = bytesize
+        self.parity = parity
+        self.stopbits = stopbits
+        self.timeout = timeout
+        self.chunk_size = chunk_size
+        self.serial_factory = serial_factory
+        self._output = output or sys.stdout
+        self._stop_event = asyncio.Event()
+        self._serial = None
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    async def run(self) -> None:
+        self._stop_event.clear()
+        if self.serial_factory is not None:
+            serial_obj = self.serial_factory()
+        else:
+            serial_obj = self._open_serial()
+        self._serial = serial_obj
+        try:
+            while not self._stop_event.is_set():
+                data = await asyncio.to_thread(serial_obj.read, self.chunk_size)
+                if data:
+                    self._emit_event(
+                        SerialEvent(
+                            timestamp=_utc_timestamp(),
+                            direction="in",
+                            payload=data.hex(),
+                        )
+                    )
+                else:
+                    await asyncio.sleep(self.timeout)
+        finally:
+            with contextlib.suppress(Exception):
+                serial_obj.close()
+
+    def _open_serial(self):
+        import serial  # type: ignore
+
+        return serial.Serial(
+            port=self.port,
+            baudrate=self.baudrate,
+            bytesize=self.bytesize,
+            parity=self.parity,
+            stopbits=self.stopbits,
+            timeout=self.timeout,
+        )
+
+    def _emit_event(self, event: SerialEvent) -> None:
+        if hasattr(self._output, "write"):
+            self._output.write(event.to_json() + "\n")
+            self._output.flush()
+        else:  # pragma: no cover - fallback for custom writers
+            self._output(event)
+
+
+__all__ = ["SerialEvent", "SerialMonitor"]

--- a/src/bus_hound_tool/usb_monitor.py
+++ b/src/bus_hound_tool/usb_monitor.py
@@ -1,0 +1,188 @@
+"""USB monitoring utilities for Windows hosts.
+
+The monitor offered in this module is intentionally lightweight – it does
+not require kernel level drivers and therefore cannot access the raw bus
+packets that specialised analysers such as Bus Hound capture.  Instead it
+focuses on functionality that is useful for application developers: it
+tracks hot‑plug events, enumerates connected devices and exports a stream
+of structured log messages describing what is connected to the host.
+
+Only Windows is supported.  The implementation polls :mod:`pyusb` on a
+configurable interval which makes the monitor easy to run without having
+to integrate with Win32 message pumps.  The polling approach works well on
+modern Windows installations as long as the libusb driver is installed for
+the device classes that need to be observed.
+
+The monitor integrates with :mod:`asyncio` so that it can be combined with
+other asynchronous workloads.
+"""
+from __future__ import annotations
+
+import asyncio
+import datetime as _dt
+import json
+import sys
+from dataclasses import dataclass, asdict
+from typing import Dict, Iterable, Optional
+
+
+def _utc_timestamp() -> str:
+    """Return an ISO 8601 timestamp in UTC with a ``Z`` suffix."""
+
+    return _dt.datetime.now(_dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(frozen=True)
+class USBDevice:
+    """Representation of a USB device.
+
+    Only a curated subset of the full USB descriptor tree is collected.
+    This keeps the monitor portable and limits the amount of privileged
+    access required to gather information.
+    """
+
+    vendor_id: str
+    product_id: str
+    bus: Optional[str] = None
+    address: Optional[str] = None
+    manufacturer: Optional[str] = None
+    product: Optional[str] = None
+    serial_number: Optional[str] = None
+
+    @classmethod
+    def from_usb_device(cls, device: "usb.core.Device") -> "USBDevice":
+        """Create a :class:`USBDevice` from a :mod:`pyusb` device object."""
+
+        # Pulling the descriptors can raise USBError when permission is
+        # denied.  They are therefore requested defensively and the
+        # monitor simply omits the information if unavailable.
+        def _safe_get(attr: str) -> Optional[str]:
+            try:
+                value = getattr(device, attr, None)
+            except Exception:  # pragma: no cover - defensive
+                return None
+            if value is None:
+                return None
+            try:
+                return str(value)
+            except Exception:  # pragma: no cover - defensive
+                return None
+
+        busnum = getattr(device, "bus", None)
+        address = getattr(device, "address", None)
+        return cls(
+            vendor_id=f"0x{int(device.idVendor):04x}",
+            product_id=f"0x{int(device.idProduct):04x}",
+            bus=str(busnum) if busnum is not None else None,
+            address=str(address) if address is not None else None,
+            manufacturer=_safe_get("manufacturer"),
+            product=_safe_get("product"),
+            serial_number=_safe_get("serial_number"),
+        )
+
+
+@dataclass(frozen=True)
+class USBEvent:
+    """Structured event emitted by :class:`USBMonitor`."""
+
+    action: str
+    timestamp: str
+    device: USBDevice
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), ensure_ascii=False)
+
+
+class USBMonitor:
+    """Asynchronous monitor that produces :class:`USBEvent` objects.
+
+    Windows is the only supported platform.  The monitor relies on periodic
+    polling of :mod:`pyusb` to detect attachments and detachments.
+    """
+
+    def __init__(
+        self,
+        *,
+        poll_interval: float = 2.0,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+        output = None,
+    ) -> None:
+        self.poll_interval = poll_interval
+        self._loop = loop
+        self._output = output or sys.stdout
+        self._stop_event = asyncio.Event()
+        self._known_devices: Dict[str, USBDevice] = {}
+
+    def stop(self) -> None:
+        """Request the monitor to stop."""
+
+        self._stop_event.set()
+
+    async def run(self) -> None:
+        """Start monitoring USB events until :meth:`stop` is called."""
+
+        loop = self._loop or asyncio.get_running_loop()
+        self._stop_event.clear()
+        if sys.platform != "win32":  # pragma: no cover - safety guard
+            raise RuntimeError("USBMonitor only supports Windows hosts")
+
+        await self._run_with_polling()
+
+    async def _run_with_polling(self) -> None:
+        while not self._stop_event.is_set():
+            current_devices = {dev.vendor_id + dev.product_id + (dev.address or ""): dev for dev in self._enumerate_devices()}
+
+            # Detect attachments
+            for key, device in current_devices.items():
+                if key not in self._known_devices:
+                    event = USBEvent(
+                        action="attach",
+                        timestamp=_utc_timestamp(),
+                        device=device,
+                    )
+                    self._emit_event(event)
+
+            # Detect detachments
+            for key, device in list(self._known_devices.items()):
+                if key not in current_devices:
+                    event = USBEvent(
+                        action="detach",
+                        timestamp=_utc_timestamp(),
+                        device=device,
+                    )
+                    self._emit_event(event)
+
+            self._known_devices = current_devices
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), timeout=self.poll_interval)
+            except asyncio.TimeoutError:
+                continue
+
+    def _emit_event(self, event: USBEvent) -> None:
+        if hasattr(self._output, "write"):
+            self._output.write(event.to_json() + "\n")
+            self._output.flush()
+        else:  # pragma: no cover - fallback for custom writers
+            self._output(event)
+
+    # ------------------------------------------------------------------
+    def _enumerate_devices(self) -> Iterable[USBDevice]:
+        try:
+            import usb.core  # type: ignore
+        except Exception:
+            return []
+
+        try:
+            devices = usb.core.find(find_all=True)
+        except Exception:
+            return []
+
+        result = []
+        for device in devices or []:
+            try:
+                result.append(USBDevice.from_usb_device(device))
+            except Exception:
+                continue
+        return result
+
+__all__ = ["USBDevice", "USBEvent", "USBMonitor"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_serial_monitor.py
+++ b/tests/test_serial_monitor.py
@@ -1,0 +1,43 @@
+import asyncio
+import io
+import json
+
+from bus_hound_tool.serial_monitor import SerialMonitor
+
+
+class DummySerial:
+    def __init__(self):
+        self._reads = [b"ABC", b"", b"\x01\x02"]
+        self.closed = False
+
+    def read(self, _: int):
+        if self._reads:
+            return self._reads.pop(0)
+        return b""
+
+    def close(self):
+        self.closed = True
+
+
+def test_serial_monitor_logs_hex_payload():
+    output = io.StringIO()
+
+    monitor = SerialMonitor(
+        "loop://",
+        serial_factory=DummySerial,
+        output=output,
+        chunk_size=3,
+    )
+
+    async def runner():
+        async def stop_later():
+            await asyncio.sleep(0.05)
+            monitor.stop()
+
+        await asyncio.gather(monitor.run(), stop_later())
+
+    asyncio.run(runner())
+
+    lines = [json.loads(line) for line in output.getvalue().splitlines() if line.strip()]
+    assert lines
+    assert lines[0]["payload"] == "414243"

--- a/tests/test_usb_monitor.py
+++ b/tests/test_usb_monitor.py
@@ -1,0 +1,54 @@
+import asyncio
+import io
+import json
+
+import pytest
+
+from bus_hound_tool.usb_monitor import USBDevice, USBMonitor
+
+
+def test_polling_emits_attach_and_detach(monkeypatch):
+    output = io.StringIO()
+    monitor = USBMonitor(poll_interval=0.01, output=output)
+
+    device = USBDevice(vendor_id="0x1111", product_id="0x2222", address="1")
+    sequence = [[device], []]
+
+    call_count = 0
+
+    def fake_enumerate():
+        nonlocal call_count
+        index = min(call_count, len(sequence) - 1)
+        call_count += 1
+        return sequence[index]
+
+    monkeypatch.setattr("bus_hound_tool.usb_monitor.sys.platform", "win32")
+    monkeypatch.setattr(monitor, "_enumerate_devices", fake_enumerate)
+
+    async def runner():
+        async def stop_later():
+            await asyncio.sleep(0.05)
+            monitor.stop()
+
+        await asyncio.gather(monitor.run(), stop_later())
+
+    asyncio.run(runner())
+
+    lines = [json.loads(line) for line in output.getvalue().splitlines() if line.strip()]
+    actions = [event["action"] for event in lines]
+
+    assert actions == ["attach", "detach"]
+    assert lines[0]["device"]["vendor_id"] == "0x1111"
+    assert lines[1]["device"]["address"] == "1"
+
+
+def test_windows_only_guard(monkeypatch):
+    output = io.StringIO()
+    monitor = USBMonitor(poll_interval=0.01, output=output)
+    monkeypatch.setattr("bus_hound_tool.usb_monitor.sys.platform", "linux")
+
+    async def runner():
+        await monitor.run()
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(runner())


### PR DESCRIPTION
## Summary
- document Windows-only support in the README and CLI messaging, including COM port examples
- simplify the USB monitor to a Windows polling backend and drop the Linux pyudev integration
- update dependencies and tests to reflect the Windows-only behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d88fb5065c8328a55533fe310f2b9b